### PR TITLE
Hotfix/fact resolution inside string

### DIFF
--- a/bin/puppet-runner
+++ b/bin/puppet-runner
@@ -130,7 +130,7 @@ def resolve_fact(fact_name, max_depth=5, current_depth=0, return_fact_value=fals
     if val == "%{::#{fact_name}}"
       warning "Fact resolves to itself, skipping"
     elsif val.instance_of?(String) and val.match(/%{::.*.}/)
-      val = resolve_fact(val,max_depth, current_depth + 1)
+      val = resolve_fact(val, max_depth, current_depth + 1, return_fact_value)
     else
       # if we have not been told to return the fact value, then return the fact key, else the value wil be returned
       val = "%{::#{fact_name}}" if return_fact_value == false

--- a/bin/puppet-runner
+++ b/bin/puppet-runner
@@ -118,7 +118,7 @@ def extract_type_from_hash(input)
 end
 
 # function to resolve inter fact references, it should return the last fact name (not value)
-def resolve_fact(fact_name, max_depth=5, current_depth=0)
+def resolve_fact(fact_name, max_depth=5, current_depth=0, return_fact_value=false)
   final_val = nil
   fact_name = fact_name.sub(/%{::/,'').sub(/}/,'')
   if max_depth == current_depth
@@ -132,7 +132,8 @@ def resolve_fact(fact_name, max_depth=5, current_depth=0)
     elsif val.instance_of?(String) and val.match(/%{::.*.}/)
       val = resolve_fact(val,max_depth, current_depth + 1)
     else
-      val = "%{::#{fact_name}}"
+      # if we have not been told to return the fact value, then return the fact key, else the value wil be returned
+      val = "%{::#{fact_name}}" if return_fact_value == false
     end
     final_val = val
   end
@@ -333,8 +334,17 @@ if options['all'] || options['prepare']
             # find each instance of a fact within the value (it may contain multiple facts
             # i.e "TEST%{::fact1}TEST%{::fact2}"
             fact_val.gsub(/}/,"}\n").scan(/%{::.*.}/).each do | fact |
-              # resolve the fact down to its last reference to another fact (not the end value)
-              resolved_fact = resolve_fact(fact)
+              # if the fact is part of a larger string set a flag to tell resolve_fact 
+              # to return the final fact value instead of the finalfact key!
+              if fact.length != fact_val.length
+                  return_fact_value = true
+              else
+                  return_fact_value = false
+              end
+
+              # resolve the fact down to its last reference to another fact (not the end value) if return_fact_value is false
+              # or down to the end value if return_fact_value is true
+              resolved_fact = resolve_fact(fact, 5, 0, return_fact_value)
               # if the resolved fact name is not the same as the original fact we found referenced
               # then replace the value in fact_val
               if !resolved_fact.nil? and resolved_fact != fact
@@ -344,7 +354,7 @@ if options['all'] || options['prepare']
             debug "Attempting to replace fact '#{fact_key}' with value '#{fact_val}' in compiled template"
             # replace the original fact reference in the template with the resovled value
             # this is done before global teansformation as they may change the final value again
-            result_template = result_template.gsub(/\"\%{::#{fact_key}}\"/, "\"#{fact_val}\"")
+            result_template = result_template.gsub(/\%{::#{fact_key}}/, "#{fact_val}")
           end
         end
 

--- a/puppet-runner.gemspec
+++ b/puppet-runner.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "2.2.10"
+  spec.add_development_dependency "bundler", "2.2.33"
   spec.add_development_dependency "rake"
   spec.add_dependency "docopt", ">= 0.5.0"
   spec.add_dependency "colorize", ">= 0.7.3"

--- a/puppet-runner.gemspec
+++ b/puppet-runner.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "puppet-runner"
-  spec.version       = "0.0.26"
+  spec.version       = "0.0.27"
   spec.authors       = ["Martin Brehovsky", "Matthew Hope"]
   spec.email         = ["mbrehovsky@adaptavist.com"]
   spec.summary       = %q{Preprocessor for hiera config}


### PR DESCRIPTION
Inter fact resolution works fine if the fact just points to another fact, however when it points to a fact that is part of a string the resolution logic fails and ends up sending the string literal of the fact KEY.
This hotfix resolves this and causes the final VALUES to be written into the puppet hiera document (/etc/puppet/hiera/hostname.eyaml)

To approve this you MAY need to see the actual problem and resolution in a demo, I can provide a video of this upon request 